### PR TITLE
test: fix the integrations for subscriptions

### DIFF
--- a/test/integrations/apimock/server/api_default.go
+++ b/test/integrations/apimock/server/api_default.go
@@ -57,20 +57,37 @@ var accountDetails = models.AccountDetails{
 	Subscriptions: accountDetailsSubscriptions,
 	MaxDevices:    5,
 }
+var expiredAccountDetails = models.ErrorSchema{
+	Code:  401,
+	Errno: 120,
+	Error: "User doesn't have an active subscription",
+}
 
 // ApiV1VpnAccountGet - Account Information
 func (router *Router) ApiV1VpnAccountGet(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-	w.WriteHeader(http.StatusOK)
-	accountDetails.Devices = devices
-	accountDetails.Subscriptions.Vpn.Active = subscriptionStatus
+	if subscriptionStatus {
+		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+		w.WriteHeader(http.StatusOK)
+		accountDetails.Devices = devices
+		accountDetails.Subscriptions.Vpn.Active = subscriptionStatus
 
-	js, err := json.Marshal(accountDetails)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+		js, err := json.Marshal(accountDetails)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Write(js)
+	} else {
+		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+		w.WriteHeader(http.StatusUnauthorized)
+		js, err := json.Marshal(expiredAccountDetails)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Write(js)
 	}
-	w.Write(js)
+
 }
 
 // ApiV1VpnDevicePost - Add Device

--- a/test/integrations/integration_helper.go
+++ b/test/integrations/integration_helper.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	"github.com/bitly/go-simplejson"
-	"github.com/stretchr/testify/assert"
 	"github.com/mozilla-services/guardian-vpn-windows/test/integrations/apimock/server/models"
+	"github.com/stretchr/testify/assert"
 )
 
 func VersionCheck(currentVersion string) (bool, error) {


### PR DESCRIPTION
This is a bug fix for integration test about subscriptions. Initially we thought the response from FxA account API would only update subscription status if the subscription of the user expired. It turned out that the whole schema of the response changed. We adjust our mock API server based on the changes.